### PR TITLE
Fix for 'cannot import name WindowsAzureMissingResourceError'

### DIFF
--- a/azurefs.py
+++ b/azurefs.py
@@ -17,8 +17,8 @@ from errno import *
 from os import getuid
 from datetime import datetime
 from fuse import FUSE, FuseOSError, Operations, LoggingMixIn
-from azure.storage import BlobService, WindowsAzureError, \
-        WindowsAzureMissingResourceError
+from azure.storage import BlobService, WindowsAzureError
+from azure import WindowsAzureMissingResourceError
 
 
 TIME_FORMAT = '%a, %d %b %Y %H:%M:%S %Z'


### PR DESCRIPTION
I've just installed Azure SDK with PIP and got the following error. After a short investigation i found that to be a small naming issue, here is a fix.

Best Regards,

Valentin

$ python azurefs.py /net/azure/ xxx 'XXXXXXXX'
Traceback (most recent call last):
  File "azurefs.py", line 20, in <module>
    from azure.storage import BlobService, WindowsAzureError, \
ImportError: cannot import name WindowsAzureMissingResourceError
$
