### PR TITLE
Adaptation of azurefs to the latest azure-sdk-for-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ sudo python setup.py install
 Install `azure-sdk-for-python`. Run `sudo easy_install azure` or `sudo pip install azure` or
 
 ```
-git clone https://github.com/WindowsAzure/azure-sdk-for-python.git
-cd azure-sdk-for-python/src
-sudo python setup.py install
+git clone git://github.com/Azure/azure-sdk-for-python.git
+cd azure-sdk-for-python
+python setup.py install
 ```
 
 Install `libfuse2`, `fuse-utils` and `libfuse-dev` dependencies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+azure-common
+azure-storage
+azure >=1.0.3


### PR DESCRIPTION
Hi 

I've modified the following 2 files in order to adapt azurefs to the latest azure-sdk-for-python. 
- azurefs.py
- README.md

Compared to the old the azure-sdk-for-python, some packages have been renamed like:
- azure.WindowsAzureError -> azure.common.AzureException and AzureHttpError
- azure.WindowsAzureMissingResourceError -> azure.common.AzureMissingResourceHttpError
- azure.storage.BlobService    -> azure.storage.blob.BlobService
  Please see the release note of azure-sdk-for-python for more detail: https://github.com/Azure/azure-sdk-for-python/releases

Thanks,
Yoichi
